### PR TITLE
Add experimental Expo iOS wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,14 @@ build/
 
 # .d.ts files aren't type-checked with skipLibCheck set to true
 *.d.ts
+!packages/mobile-ios/expo-env.d.ts
+
+# Expo / React Native mobile build artifacts
+packages/mobile-ios/.expo
+packages/mobile-ios/.expo-shared
+packages/mobile-ios/dist
+packages/mobile-ios/build
+packages/mobile-ios/ios/Pods
+packages/mobile-ios/ios/build
+packages/mobile-ios/ios/DerivedData
+packages/mobile-ios/ios/*.xcworkspace

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ There are four ways to deploy Actual:
 1. Self-hosted by using [a Docker image](https://actualbudget.org/docs/install/docker)
 1. Local-only apps - [downloadable Windows, Mac and Linux apps](https://actualbudget.org/download/) you can run on your device
 
+### Experimental iOS app
+
+An Expo-managed wrapper for the web client now lives in [`packages/mobile-ios`](./packages/mobile-ios). It loads an existing Actual instance inside a native WebView so you can run Actual on iPhone and iPad.
+
+```sh
+# Start the web client (in another terminal)
+yarn start:browser
+
+# Launch the Expo development server
+yarn workspace @actual-app/mobile-ios start
+```
+
+Override the backend URL by exporting `EXPO_PUBLIC_ACTUAL_URL` before starting Expo. See the package README for prebuild/bundling instructions and additional details.
+
 Learn more in the [installation instructions docs](https://actualbudget.org/docs/install/).
 
 ## Ready to Start Budgeting?

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,6 +149,14 @@ export default pluginTypescript.config(
       },
     },
   },
+  {
+    files: ['packages/mobile-ios/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.reactnative,
+      },
+    },
+  },
   pluginReact.configs.flat.recommended,
   pluginReact.configs.flat['jsx-runtime'],
   pluginTypescript.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "start:service-plugins": "yarn workspace plugins-service watch",
     "start:browser-backend": "yarn workspace loot-core watch:browser",
     "start:browser-frontend": "yarn workspace @actual-app/web start:browser",
+    "start:mobile": "yarn workspace @actual-app/mobile-ios start",
+    "start:mobile:ios": "yarn workspace @actual-app/mobile-ios start:ios",
     "build:browser-backend": "yarn workspace loot-core build:browser",
     "build:server": "yarn build:browser && yarn workspace @actual-app/sync-server build",
     "build:browser": "./bin/package-browser",

--- a/packages/mobile-ios/App.tsx
+++ b/packages/mobile-ios/App.tsx
@@ -1,0 +1,238 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  BackHandler,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+  useColorScheme,
+} from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import Constants from 'expo-constants';
+import * as Linking from 'expo-linking';
+import type { ShouldStartLoadRequest, WebViewErrorEvent, WebViewNavigation } from 'react-native-webview';
+import { WebView } from 'react-native-webview';
+
+const DEFAULT_APP_URL = 'http://localhost:3000';
+
+const getConfiguredAppUrl = (): string => {
+  const extra = Constants.expoConfig?.extra ?? {};
+  const url = typeof extra?.appUrl === 'string' ? extra.appUrl : undefined;
+  if (url && url.trim().length > 0) {
+    return url.trim();
+  }
+  return DEFAULT_APP_URL;
+};
+
+const isHttpScheme = (url: string) => /^https?:/i.test(url);
+
+const App = (): JSX.Element => {
+  const colorScheme = useColorScheme();
+  const webViewRef = useRef<WebView>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  const appUrl = useMemo(() => getConfiguredAppUrl(), []);
+
+  const allowedHosts = useMemo(() => {
+    try {
+      const base = new URL(appUrl);
+      const hosts = new Set<string>([base.host, 'localhost', '127.0.0.1']);
+      if (base.hostname === 'localhost' && base.port) {
+        hosts.add(`${base.hostname}:${base.port}`);
+      }
+      return hosts;
+    } catch (error) {
+      console.warn('Unable to derive base host from app URL', error);
+      return new Set<string>();
+    }
+  }, [appUrl]);
+
+  React.useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return undefined;
+    }
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (canGoBack) {
+        webViewRef.current?.goBack();
+        return true;
+      }
+      return false;
+    });
+
+    return () => subscription.remove();
+  }, [canGoBack]);
+
+  const handleShouldStartLoad = useCallback(
+    (request: ShouldStartLoadRequest) => {
+      const { url } = request;
+
+      if (!url) {
+        return true;
+      }
+
+      if (!isHttpScheme(url) || url.startsWith('about:') || url.startsWith('blob:')) {
+        return true;
+      }
+
+      try {
+        const parsedUrl = new URL(url);
+        if (allowedHosts.has(parsedUrl.host)) {
+          return true;
+        }
+      } catch (error) {
+        console.warn('Failed to parse target URL', error);
+        return false;
+      }
+
+      Linking.openURL(url).catch(err => console.error('Unable to open external URL', err));
+      return false;
+    },
+    [allowedHosts],
+  );
+
+  const handleNavigationStateChange = useCallback((event: WebViewNavigation) => {
+    setCanGoBack(event.canGoBack ?? false);
+  }, []);
+
+  const handleReload = useCallback(() => {
+    setLastError(null);
+    setIsLoading(true);
+    webViewRef.current?.reload();
+  }, []);
+
+  const handleLoadError = useCallback((event: WebViewErrorEvent) => {
+    setLastError(event.nativeEvent.description ?? 'Unknown error');
+    setIsLoading(false);
+  }, []);
+
+  return (
+    <SafeAreaView style={[styles.container, colorScheme === 'dark' ? styles.darkBackground : styles.lightBackground]}>
+      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+      <View style={styles.webViewWrapper}>
+        <WebView
+          ref={webViewRef}
+          source={{ uri: appUrl }}
+          onLoadStart={() => {
+            setLastError(null);
+            setIsLoading(true);
+          }}
+          onLoadEnd={() => setIsLoading(false)}
+          onError={handleLoadError}
+          onHttpError={handleLoadError}
+          onContentProcessDidTerminate={() => webViewRef.current?.reload()}
+          onShouldStartLoadWithRequest={handleShouldStartLoad}
+          onNavigationStateChange={handleNavigationStateChange}
+          allowsBackForwardNavigationGestures
+          allowsInlineMediaPlayback
+          javaScriptEnabled
+          domStorageEnabled
+          startInLoadingState
+          pullToRefreshEnabled
+          mediaPlaybackRequiresUserAction={false}
+          automaticallyAdjustsScrollIndicatorInsets
+          setSupportMultipleWindows={false}
+          sharedCookiesEnabled
+          decelerationRate="normal"
+          style={styles.webView}
+        />
+        {(isLoading || lastError) && (
+          <View style={[styles.overlay, colorScheme === 'dark' ? styles.darkBackground : styles.lightBackground]}>
+            {isLoading && !lastError ? (
+              <ActivityIndicator size="large" color={colorScheme === 'dark' ? '#ffffff' : '#111827'} />
+            ) : (
+              <View style={styles.errorContainer}>
+                <Text style={[styles.errorTitle, colorScheme === 'dark' ? styles.errorTitleDark : styles.errorTitleLight]}>
+                  Something went wrong
+                </Text>
+                <Text style={[styles.errorMessage, colorScheme === 'dark' ? styles.errorMessageDark : styles.errorMessageLight]}>
+                  {lastError}
+                </Text>
+                <Pressable
+                  onPress={handleReload}
+                  style={styles.retryButton}
+                  accessibilityRole="button"
+                  hitSlop={12}
+                >
+                  <Text style={styles.retryButtonText}>Try again</Text>
+                </Pressable>
+              </View>
+            )}
+          </View>
+        )}
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  webViewWrapper: {
+    flex: 1,
+  },
+  webView: {
+    flex: 1,
+    backgroundColor: 'transparent',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  errorContainer: {
+    alignItems: 'center',
+    maxWidth: 320,
+  },
+  errorTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  errorTitleLight: {
+    color: '#111827',
+  },
+  errorTitleDark: {
+    color: '#f9fafb',
+  },
+  errorMessage: {
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  errorMessageLight: {
+    color: '#1f2937',
+  },
+  errorMessageDark: {
+    color: '#e5e7eb',
+  },
+  retryButton: {
+    paddingHorizontal: 28,
+    paddingVertical: 12,
+    borderRadius: 999,
+    backgroundColor: '#0ea5e9',
+    marginTop: 16,
+  },
+  retryButtonText: {
+    color: '#f8fafc',
+    fontWeight: '600',
+    fontSize: 15,
+    letterSpacing: 0.4,
+  },
+  lightBackground: {
+    backgroundColor: '#f9fafb',
+  },
+  darkBackground: {
+    backgroundColor: '#0b1120',
+  },
+});
+
+export default App;

--- a/packages/mobile-ios/README.md
+++ b/packages/mobile-ios/README.md
@@ -1,0 +1,71 @@
+# Actual Mobile (iOS)
+
+This package contains an experimental iOS application for Actual. The app is built with Expo and wraps the existing web client inside a secure `WebView`, so you can interact with your self-hosted or locally running Actual instance on iPhone and iPad.
+
+> **Status:** MVP. The initial goal is to make the current web client available on iOS quickly. Native integrations (files, notifications, biometrics, offline sync, etc.) can be layered on top of this foundation later.
+
+## Prerequisites
+
+- Xcode 15 or newer installed on macOS.
+- `cocoapods` installed (`sudo gem install cocoapods`).
+- Yarn 4 (already configured at the repository root).
+
+## Getting started
+
+1. Install dependencies from the repository root:
+
+   ```sh
+   yarn install
+   ```
+
+2. Build the Actual web client so the mobile shell can load it. For local development this means running the desktop/web dev server:
+
+   ```sh
+   yarn start:browser
+   ```
+
+   The mobile app points to `http://localhost:3000` by default. When testing on a device, expose the dev server on your LAN and update the URL (see below).
+
+3. In a separate terminal, launch the Expo development server for iOS:
+
+   ```sh
+   yarn workspace @actual-app/mobile-ios start
+   ```
+
+4. Press `i` in the Expo CLI UI to open the app in the iOS simulator, or use the Expo Go app / a custom dev client on your device.
+
+### Configuring the backend URL
+
+Set `EXPO_PUBLIC_ACTUAL_URL` before starting the Expo server to point at a reachable Actual instance:
+
+```sh
+EXPO_PUBLIC_ACTUAL_URL="http://192.168.0.42:3000" \
+  yarn workspace @actual-app/mobile-ios start
+```
+
+The URL is stored in Expo configuration and read at runtime by the app shell.
+
+## Producing an iOS build
+
+1. Generate native iOS project files (this step creates the `packages/mobile-ios/ios` directory):
+
+   ```sh
+   yarn workspace @actual-app/mobile-ios expo prebuild --platform ios
+   ```
+
+2. Open the generated workspace in Xcode and build/archive as usual:
+
+   ```sh
+   open packages/mobile-ios/ios/Actual\ Mobile.xcworkspace
+   ```
+
+3. Update the bundle identifier or signing configuration in `app.config.ts` before submitting to TestFlight / the App Store.
+
+## Implementation notes
+
+- The shell relies on the existing Actual web UI. Authentication, budgeting flows, and plugins all work the same way they do in the browser.
+- External links are opened using the system browser while internal navigation stays within the WebView.
+- The WebView preserves cookies and session data so you stay signed in between launches.
+- The native wrapper handles dark/light themes automatically and shows a fallback UI if the web app fails to load.
+
+Future iterations can progressively replace the WebView with native screens or add platform-specific enhancements using Expo modules.

--- a/packages/mobile-ios/app.config.ts
+++ b/packages/mobile-ios/app.config.ts
@@ -1,0 +1,55 @@
+import type { ExpoConfig, ConfigContext } from 'expo/config';
+
+const DEFAULT_APP_URL = 'http://localhost:3000';
+
+const createConfig = ({ config }: ConfigContext): ExpoConfig => {
+  const appUrl = process.env.EXPO_PUBLIC_ACTUAL_URL ?? DEFAULT_APP_URL;
+
+  return {
+    ...config,
+    name: 'Actual Mobile',
+    slug: 'actual-mobile',
+    version: '1.0.0',
+    orientation: 'default',
+    platforms: ['ios'],
+    scheme: 'actual',
+    userInterfaceStyle: 'automatic',
+    icon: '../desktop-client/public/maskable-512x512.png',
+    splash: {
+      image: '../desktop-client/public/android-chrome-192x192.png',
+      resizeMode: 'contain',
+      backgroundColor: '#0b1120',
+    },
+    assetBundlePatterns: ['**/*'],
+    ios: {
+      supportsTablet: true,
+      bundleIdentifier: 'org.actualbudget.mobile',
+      buildNumber: '1.0.0',
+      infoPlist: {
+        NSCameraUsageDescription: 'Actual requires camera access to scan documents for import.',
+        NSPhotoLibraryAddUsageDescription: 'Actual saves exported budgets to your photo library when requested.',
+        NSAppTransportSecurity: {
+          NSAllowsArbitraryLoads: true,
+          NSExceptionDomains: {
+            localhost: {
+              NSTemporaryExceptionAllowsInsecureHTTPLoads: true,
+              NSTemporaryExceptionMinimumTLSVersion: 'TLSv1.2',
+            },
+          },
+        },
+      },
+    },
+    runtimeVersion: {
+      policy: 'nativeVersion',
+    },
+    extra: {
+      ...config.extra,
+      appUrl,
+    },
+    experiments: {
+      typedRoutes: true,
+    },
+  };
+};
+
+export default createConfig;

--- a/packages/mobile-ios/babel.config.js
+++ b/packages/mobile-ios/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/packages/mobile-ios/expo-env.d.ts
+++ b/packages/mobile-ios/expo-env.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    EXPO_PUBLIC_ACTUAL_URL?: string;
+  }
+}

--- a/packages/mobile-ios/metro.config.js
+++ b/packages/mobile-ios/metro.config.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const { getDefaultConfig } = require('@expo/metro-config');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [workspaceRoot];
+config.resolver.disableHierarchicalLookup = true;
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules'),
+];
+
+module.exports = config;

--- a/packages/mobile-ios/package.json
+++ b/packages/mobile-ios/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@actual-app/mobile-ios",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo/AppEntry",
+  "scripts": {
+    "start": "expo start --dev-client",
+    "start:ios": "expo run:ios",
+    "start:web": "expo start --web",
+    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "expo": "~52.0.26",
+    "expo-linking": "~6.0.2",
+    "expo-status-bar": "~2.0.1",
+    "react": "18.3.1",
+    "react-native": "0.76.6",
+    "react-native-safe-area-context": "4.12.0",
+    "react-native-webview": "13.12.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.26.0",
+    "@expo/metro-config": "^0.18.1",
+    "@types/react": "^18.2.48",
+    "@types/react-native": "^0.76.5",
+    "babel-preset-expo": "^11.0.7",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/mobile-ios/tsconfig.json
+++ b/packages/mobile-ios/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-native",
+    "types": ["react", "react-native", "expo"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "module": "esnext",
+    "target": "esnext",
+    "allowJs": false
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "exclude": ["node_modules", "build", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a new `packages/mobile-ios` Expo workspace that wraps the Actual web client in a native iOS WebView shell
- document the mobile workflow in the root README and package README, and expose yarn scripts for launching the iOS dev server
- update linting and gitignore configuration to support the new mobile package

## Testing
- not run (requires the Expo toolchain and iOS simulator)


------
https://chatgpt.com/codex/tasks/task_e_68e57cec9be483208adcbaabe7fe674a